### PR TITLE
feat: improve user notification message

### DIFF
--- a/pages/api/prox2_work.ts
+++ b/pages/api/prox2_work.ts
@@ -111,7 +111,7 @@ export default async function handler(
   console.log(`Notifying user...`);
   await succeedRequest(
     data.response_url,
-    `Your message has been staged as confession #${confession_id} and will appear here after review by the confessions team!`
+    `Your message has been staged as confession #${confession_id} and will appear in <#CNMU9L92Q> if approved by the confessions review team!`
   );
   console.log(`Request success`);
   res.writeHead(200).end();


### PR DESCRIPTION
Now that confessions can only be sent from a DM the user notification message should reference the confessions channel instead of saying "will appear here". Thanks for making this ani! You've done an amazing job with it :).

Signed-off-by: Matthew Gleich <git@mattglei.ch>