### PR TITLE
Improvements to undo + support for old handler callback format

### DIFF
--- a/lib/interaction_handlers/block_action.ts
+++ b/lib/interaction_handlers/block_action.ts
@@ -92,28 +92,43 @@ const block_action: InteractionHandler<BlockActionInteraction> = async data => {
 
             // await unviewConfession(repo, data.message.ts, reviewer_uid, undoer_uid);
 
-            const resp = await web.views.open({
-                trigger_id: data.trigger_id,
-                view: {
-                    callback_id: undo_confirm_id({
-                        ts: data.message.ts,
-                        reviewer_uid,
-                        undoer_uid
-                    }),
-                    type: "modal",
-                    title: new PlainText(`Undo confession review`).render(),
-                    submit: new PlainText("Undo").render(),
-                    close: new PlainText("Cancel").render(),
-                    blocks: new Blocks([
-                        // text
-                        new TextSection(
-                            new MarkdownText(
-                                "Undoing approval is undoable, however replies will not be preserved."
+            const resp = Number(new Date()) - Number(data.message.edited?.ts ?? data.message.ts) * 1000 > /* 1 week */ 7 * 24 * 60 * 60 * 1000
+                ? await web.views.open({
+                    trigger_id: data.trigger_id,
+                    view: {
+                        type: "modal",
+                        title: new PlainText(`Undo confession review`).render(),
+                        close: new PlainText("Close").render(),
+                        blocks: new Blocks([
+                            new TextSection(
+                                new MarkdownText(
+                                    "It has been a week since the review of this confession, so you can not undo it."
+                                )
                             )
-                        )
-                    ]).render()
-                }
-            });
+                        ]).render()
+                    }
+                }) : await web.views.open({
+                    trigger_id: data.trigger_id,
+                    view: {
+                        callback_id: undo_confirm_id({
+                            ts: data.message.ts,
+                            reviewer_uid,
+                            undoer_uid
+                        }),
+                        type: "modal",
+                        title: new PlainText(`Undo confession review`).render(),
+                        submit: new PlainText("Undo").render(),
+                        close: new PlainText("Cancel").render(),
+                        blocks: new Blocks([
+                            // text
+                            new TextSection(
+                                new MarkdownText(
+                                    "Undoing approval is undoable, however replies will not be preserved."
+                                )
+                            )
+                        ]).render()
+                    }
+                });
             if (!resp.ok) {
                 throw "Failed to open modal";
             }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -204,7 +204,7 @@ export async function stageDMConfession(
   console.log(`Posting confirmation message...`);
   const confirmation_message = await web.chat.postMessage({
     channel: uid,
-    text: "",
+    text: "Would you like to stage this confession?",
     thread_ts: message_ts,
     reply_broadcast: true,
     blocks: new Blocks([
@@ -445,7 +445,7 @@ export async function viewConfession(
         new TextSection(new MarkdownText(statusText)),
         new ActionsSection([
             new ButtonAction(
-                new PlainText(":oops: Undo"),
+                new PlainText(":rewind: Undo"),
                 "undo",
                 "undo"
             )
@@ -549,7 +549,7 @@ export async function unviewConfession(
 
   // Log undo
   console.log(`Logging undo...`);
-  const log_message_text = `:oops: ${old_approved ? "Approval" : "Rejection"} (by <@${reviewer_uid}>) of confession #${record.id} undone by <@${undoer_uid}>`;
+  const log_message_text = `:rewind: ${old_approved ? "Approval" : "Rejection"} (by <@${reviewer_uid}>) of confession #${record.id} undone by <@${undoer_uid}>`;
   const log_message = await web.chat.postMessage({
     channel: staging_channel,
     text: "",

--- a/pages/api/interaction_work.ts
+++ b/pages/api/interaction_work.ts
@@ -47,6 +47,10 @@ export interface BlockActionInteraction {
     text: string;
     ts: string;
     thread_ts?: string;
+    edited?: {
+      user: string;
+      ts: string;
+    }
   };
   actions: {
     block_id: string;


### PR DESCRIPTION
This PR:
- adds support for the old handler callback format, so when you update all the previous unviewed staging messages still work
- adds a 7 day limit on undo
- changes the undo emoji to not be specific to the HC workspace