### PR TITLE
Adding option to send HQ related confession to #meta

### DIFF
--- a/lib/interaction_handlers/block_action.ts
+++ b/lib/interaction_handlers/block_action.ts
@@ -47,6 +47,10 @@ const block_action: InteractionHandler<BlockActionInteraction> = async data => {
             }
             break;
         }
+        case "approve:hq": {
+            await viewConfession(repo, data.message.ts, true, data.user.id, null, true);
+            break;
+          }         
         case "stage": {
             console.log(`Stage of message thread_ts=${data.message.thread_ts}`);
             // Get message contents

--- a/lib/interaction_handlers/block_action.ts
+++ b/lib/interaction_handlers/block_action.ts
@@ -47,7 +47,7 @@ const block_action: InteractionHandler<BlockActionInteraction> = async data => {
             }
             break;
         }
-        case "approve:hq": {
+        case "approve:meta": {
             await viewConfession(repo, data.message.ts, true, data.user.id, null, true);
             break;
           }         

--- a/lib/interaction_handlers/view_submission.ts
+++ b/lib/interaction_handlers/view_submission.ts
@@ -3,7 +3,7 @@
 import { InteractionHandler, ViewSubmissionInteraction } from "../../pages/api/interaction_work";
 import { sameUser, unviewConfession, viewConfession, web } from "../main";
 import { MarkdownText, TextSection } from "../block_builder";
-import { confessions_channel } from "../secrets_wrapper";
+import { confessions_channel, meta_channel } from "../secrets_wrapper";
 import { sanitize } from "../sanitizer";
 import getRepository from "../db";
 
@@ -87,7 +87,7 @@ const view_submission: InteractionHandler<ViewSubmissionInteraction> = async (da
 
             // Reply in thread
             const r = await web.chat.postMessage({
-                channel: confessions_channel,
+                channel: record.meta ? meta_channel : confessions_channel,
                 text: sanitize(data.view.state.values.reply.confession_reply.value),
                 thread_ts: published_ts,
             });
@@ -147,7 +147,7 @@ const view_submission: InteractionHandler<ViewSubmissionInteraction> = async (da
                     /\:/g,
                     ""
                 ),
-                channel: confessions_channel,
+                channel: record.meta ? meta_channel : confessions_channel,
                 timestamp: thread_ts,
             });
             if (!react_res.ok) throw `Failed to react`;
@@ -185,6 +185,7 @@ const view_submission: InteractionHandler<ViewSubmissionInteraction> = async (da
 
             // Reply in thread
             const r = await web.chat.postMessage({
+                // NOTE: no TWs for meta approvals
                 channel: confessions_channel,
                 text: sanitize(updatedRecord!.text),
                 thread_ts: updatedRecord?.published_ts,

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -34,6 +34,7 @@ import {
   staging_channel,
   confessions_channel,
   slack_signing_secret,
+  meta_channel,
 } from "./secrets_wrapper";
 import {
   ActionsSection,
@@ -304,6 +305,11 @@ const getStagingMessageBlocks = (id: number, text: string) => new Blocks([
         "approve:tw",
         "approve:tw"
     ),
+    new ButtonAction(
+        new PlainText(":office: Approve for HQ"),
+        "approve:hq",
+        "approve:hq"
+    ),
   ]),
 ]).render();
 
@@ -377,7 +383,8 @@ export async function viewConfession(
   staging_ts: string,
   approved: boolean,
   reviewer_uid: string,
-  tw_text: string | null = null
+  tw_text: string | null = null,
+  isHQ: boolean = false
 ): Promise<void> {
   console.log(
     `${
@@ -403,10 +410,11 @@ export async function viewConfession(
   }
   // Publish record and update
   let ts = null;
+  let targetChannel = isHQ ? meta_channel : confessions_channel;
   if (approved) {
     console.log(`Publishing message...`);
     const published_message = await web.chat.postMessage({
-      channel: confessions_channel,
+      channel: targetChannel,
       text: sanitize(
         `*${record.id}*:${tw_text ? " TW:" : ""} ${tw_text ?? record.text} ${
           tw_text?.trim() ? "— open thread to view" : ""

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -10,7 +10,7 @@ export class Confession {
   @Column()
   viewed?: boolean;
   // Whether "Approve for meta" was selected instead of "Approve"
-  @Column()
+  @Column({ nullable: true })
   meta?: boolean;
 
   @Column("text")

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -9,6 +9,9 @@ export class Confession {
   approved?: boolean;
   @Column()
   viewed?: boolean;
+  // Whether "Approve for meta" was selected instead of "Approve"
+  @Column()
+  meta?: boolean;
 
   @Column("text")
   text!: string;

--- a/lib/secrets_wrapper.ts
+++ b/lib/secrets_wrapper.ts
@@ -24,6 +24,7 @@ export let airtable_api_key: string | null;
 export let airtable_base: string | null;
 export let staging_channel: string;
 export let confessions_channel: string;
+export let meta_channel: string;
 export let slack_signing_secret: string;
 export let postgres_url: string;
 
@@ -46,6 +47,7 @@ try {
   token = secrets.token;
   staging_channel = secrets.staging_channel;
   confessions_channel = secrets.confessions_channel;
+  meta_channel = secrets.meta_channel;
   slack_signing_secret = secrets.slack_signing_secret;
   postgres_url = secrets.postgres_url;
   airtable_api_key = secrets.airtable_api_key ?? null;
@@ -54,6 +56,7 @@ try {
   token = check_env("SLACK_BOT_TOKEN");
   staging_channel = check_env("STAGING_CHANNEL_ID");
   confessions_channel = check_env("CONFESSIONS_CHANNEL_ID");
+  meta_channel = check_env("META_CHANNEL_ID");
   slack_signing_secret = check_env("SLACK_SIGNING_SECRET");
   postgres_url = check_env("POSTGRES_URL");
   airtable_api_key = null;


### PR DESCRIPTION
Task: HQ-focused confessions should be posted to a separate channel like #meta. The same bot and CRT team will be used but with a separate button for approving these changes.

**Requirement before merge**: add META_CHANNEL_ID on .env or JSON file and add meta channel id on it.

Feel free to request a review if there is better naming on those variables or implementation logic.