### PR TITLE
Add confirmation modal to "approve for meta"

### DIFF
--- a/lib/block_builder.ts
+++ b/lib/block_builder.ts
@@ -69,7 +69,7 @@ export class ActionConfirm extends Renderable {
     private text: PlainText,
     private confirm: PlainText,
     private deny: PlainText,
-    style: "primary" | "danger" = "primary"
+    public style: "primary" | "danger" = "primary"
   ) {
     super();
   }

--- a/lib/block_builder.ts
+++ b/lib/block_builder.ts
@@ -63,13 +63,36 @@ abstract class Action extends Renderable {
   }
 }
 
+export class ActionConfirm extends Renderable {
+  constructor(
+    private title: PlainText,
+    private text: PlainText,
+    private confirm: PlainText,
+    private deny: PlainText,
+    style: "primary" | "danger" = "primary"
+  ) {
+    super();
+  }
+
+  render(): any {
+    return {
+      title: this.title.render(),
+      text: this.text.render(),
+      confirm: this.confirm.render(),
+      deny: this.deny.render(),
+      style: this.style,
+    }
+  }
+}
+
 abstract class Accessory extends Renderable {}
 
 export class ExternalSelectAction extends Action implements Accessory {
   constructor(
     private placeholder: Text,
     private min_query_length: number,
-    action_id: string
+    action_id: string,
+    private confirm: ActionConfirm | null = null
   ) {
     super(action_id);
   }
@@ -80,6 +103,7 @@ export class ExternalSelectAction extends Action implements Accessory {
       placeholder: this.placeholder.render(),
       min_query_length: this.min_query_length,
       action_id: this.action_id,
+      confirm: this.confirm?.render(),
     };
   }
 }
@@ -143,7 +167,8 @@ export class ButtonAction extends Action {
   constructor(
     private text: PlainText,
     private value: string,
-    action_id: string
+    action_id: string,
+    private confirm: ActionConfirm | null = null
   ) {
     super(action_id);
   }
@@ -154,6 +179,7 @@ export class ButtonAction extends Action {
       text: this.text.render(),
       value: this.value,
       action_id: this.action_id,
+      confirm: this.confirm?.render(),
     };
   }
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -44,7 +44,7 @@ import {
   MarkdownText,
   PlainText,
   TextSection,
-	ActionConfirm,
+  ActionConfirm,
 } from "./block_builder";
 
 export const api_config = {
@@ -312,10 +312,10 @@ const getStagingMessageBlocks = (id: number, text: string) => new Blocks([
         "approve:meta",
         "approve:meta",
 				new ActionConfirm(
-					new PlainText("Approve for meta"),
-					new PlainText(`Are you sure you want to approve this confession for meta?`),
-					new PlainText("Approve"),
-					new PlainText("Deny")
+				  new PlainText("Approve for meta"),
+				  new PlainText(`Are you sure you want to approve this confession for meta?`),
+				  new PlainText("Approve"),
+				  new PlainText("Deny")
 				)
     ),
   ]),

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -44,6 +44,7 @@ import {
   MarkdownText,
   PlainText,
   TextSection,
+	ActionConfirm,
 } from "./block_builder";
 
 export const api_config = {
@@ -309,7 +310,13 @@ const getStagingMessageBlocks = (id: number, text: string) => new Blocks([
     new ButtonAction(
         new PlainText(":office: Approve for meta"),
         "approve:meta",
-        "approve:meta"
+        "approve:meta",
+				new ActionConfirm(
+					new PlainText("Approve for meta"),
+					new PlainText(`Are you sure you want to approve this confession for meta?`),
+					new PlainText("Approve"),
+					new PlainText("Deny")
+				)
     ),
   ]),
 ]).render();

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -312,10 +312,10 @@ const getStagingMessageBlocks = (id: number, text: string) => new Blocks([
         "approve:meta",
         "approve:meta",
 				new ActionConfirm(
-				  new PlainText("Approve for meta"),
-				  new PlainText(`Are you sure you want to approve this confession for meta?`),
-				  new PlainText("Approve"),
-				  new PlainText("Deny")
+				    new PlainText("Approve for meta"),
+				    new PlainText(`Are you sure you want to approve this confession for meta?`),
+				    new PlainText("Approve"),
+				    new PlainText("Deny")
 				)
     ),
   ]),


### PR DESCRIPTION
Meta is usually for more serious topics. That being said, there have been a few times where CRT reviewers have accidentally "fat fingered" the `Approve for meta` button instead of `Approve with TW`.

While I'm not saying those members did it intentionally or they didn't realize they did so, it would be nice to have some sort of confirmation as to whether a staged confession should go to meta.

This PR implements the `ActionConfirm` interface (also known as the [confirmation dialog object](https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object) in the Slack API documentation), and adds it to the constructor of the two currently supported blocks, `ExternalSelectAction` and `ButtonAction`. It also adds an `ActionConfirm` to the "Approve for meta" button.

> [!NOTE]
> This PR hasn't been tested since I'm on school WiFi, and both Slack and SSH is blocked. I expect it shouldn't break much, but it still would be nice for someone else to test it (unless I get home before someone else tests) to make sure I haven't broken anything to do with block rendering.